### PR TITLE
Remove dependency on enummapset-th

### DIFF
--- a/maplike.cabal
+++ b/maplike.cabal
@@ -23,5 +23,5 @@ source-repository head
 
 library
   exposed-modules:     Data.Maplike.Class, Data.Maplike.Lazy, Data.Maplike.Strict
-  build-depends:       base >=4.8 && <5, enummapset-th >=0.6 && <0.7, hashable >=1.2 && <1.4, unordered-containers >=0.2 && <0.3, containers >=0.5 && <0.7
+  build-depends:       base >=4.8 && <5, hashable >=1.2 && <1.4, unordered-containers >=0.2 && <0.3, containers >=0.5 && <0.7
   default-language:    Haskell2010


### PR DESCRIPTION
I'm sure I'm just missing the reason why this exists.